### PR TITLE
Make api dependencies to implementation they are omitted from jarfile…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,10 +81,10 @@ dependencies {
   testImplementation "org.junit.platform:junit-platform-launcher:$jupiterVersion"
 
   // Project specific dependencies
-  api "org.springframework.boot:spring-boot-starter-artemis:$springBootVersion"
-  api "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-  api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
-  api "io.swagger.parser.v3:swagger-parser:2.1.35"
+  implementation "org.springframework.boot:spring-boot-starter-artemis:$springBootVersion"
+  implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+  implementation "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
+  implementation "io.swagger.parser.v3:swagger-parser:2.1.35"
 
   implementation "org.mapstruct:mapstruct:1.5.5.Final"
   annotationProcessor "org.mapstruct:mapstruct-processor:1.5.5.Final"

--- a/demo-project/docker-compose.yml
+++ b/demo-project/docker-compose.yml
@@ -1,9 +1,0 @@
-services:
-  artemis:
-    image: apache/activemq-artemis:2.42.0
-    environment:
-      ARTEMIS_USER: artemis
-      ARTEMIS_PASSWORD: artemis
-    ports:
-      - "61616:61616"
-      - "8161:8161"


### PR DESCRIPTION
… cos

plugins {
  id 'java-library'

  Drop docker-compose we dont need now that we happily using TestContainers for artemis
